### PR TITLE
Jim/restore ssh related changes

### DIFF
--- a/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
+++ b/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
@@ -28,7 +28,15 @@ jobs:
                   flutter-version: '3.10.6'
                   channel: 'stable'
                   cache: true
+
+            - name: Add SSH key
+              run: |
+                  mkdir -p ~/.ssh
+                  echo "${{ secrets.SSH_KEY }}" > ~/.ssh/github_action_key
+                  chmod 600 ~/.ssh/github_action_key
             - name: Build flutter
+              env:
+                  GIT_SSH_COMMAND: 'ssh -i ~/.ssh/github_action_key'
               run: |
                   cd derivatives-charts/chart_app
                   flutter pub get

--- a/chart_app/pubspec.yaml
+++ b/chart_app/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
     deriv_lint:
         git:
-            url: https://github.com/deriv-com/flutter-deriv-packages.git
+            url: git@github.com:deriv-com/flutter-deriv-packages.git
             path: packages/deriv_lint
             ref: dev
     flutter_test:


### PR DESCRIPTION
This pull request introduces changes to enable SSH-based authentication for accessing private repositories and updates the dependency configuration in the `chart_app` project. The most important changes include adding an SSH key setup in the GitHub Actions workflow and modifying the dependency URL in the `pubspec.yaml` file to use an SSH URL.

### Workflow enhancements:
* [`.github/workflows/publish_deriv_charts_and_update_deriv_app.yml`](diffhunk://#diff-31a7ee01219fd679ab89496ee05c3e71c341dd470217d204c589c072615c3895R31-R39): Added a step to configure an SSH key (`secrets.SSH_KEY`) for secure access to private repositories and updated the `GIT_SSH_COMMAND` environment variable to use this key during the build process.

### Dependency configuration updates:
* [`chart_app/pubspec.yaml`](diffhunk://#diff-58f21c2ed39389e1be1ff95c5054a6d970f3a67ddf61da0b0bc665a6fe5e1db0L19-R19): Changed the `deriv_lint` dependency URL from HTTPS to SSH (`git@github.com:deriv-com/flutter-deriv-packages.git`) to align with the SSH-based authentication setup.