### PR TITLE
build: override package

### DIFF
--- a/chart_app/pubspec.yaml
+++ b/chart_app/pubspec.yaml
@@ -22,6 +22,13 @@ dev_dependencies:
     flutter_test:
         sdk: flutter
 
+dependency_overrides:
+    deriv_technical_analysis:
+        git:
+            url: https://github.com/deriv-com/flutter-deriv-packages.git
+            path: packages/deriv_technical_analysis
+            ref: deriv_technical_analysis-v1.1.2
+
 flutter:
     fonts:
         - family: IBMPlexSans


### PR DESCRIPTION
This pull request introduces a dependency override in the `chart_app/pubspec.yaml` file to use a specific version of the `deriv_technical_analysis` package from a Git repository.

* [`chart_app/pubspec.yaml`](diffhunk://#diff-58f21c2ed39389e1be1ff95c5054a6d970f3a67ddf61da0b0bc665a6fe5e1db0R25-R31): Added a `dependency_overrides` section to point to the `deriv_technical_analysis` package hosted on GitHub, specifying the path and version reference (`deriv_technical_analysis-v1.1.2`).