### PR TITLE
fix: make package public

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">
-  SmartCharts
+  DerivitivesCharts
 </h1>
 
-SmartCharts is both the name of the app ([charts.binary.com](https://charts.binary.com/)) and the charting library.
+DerivitivesCharts is both the name of the app ([charts.binary.com](https://charts.binary.com/)) and the charting library.
 
 [![npm](https://img.shields.io/badge/npm->=9-blue)](https://www.npmjs.com/package/@deriv-com/derivatives-charts) ![node](https://img.shields.io/badge/node-%3E%3D18-blue.svg)
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "sourceMap": false,
         "instrument": false
     },
+    "private": false,
     "scripts": {
         "build": "rimraf dist && cross-env NODE_ENV=production webpack --mode=production --progress",
         "build:app": "cross-env BUILD_MODE='app' npm run build",


### PR DESCRIPTION
This pull request includes two key changes: a rebranding effort reflected in the `README.md` file and an update to the `package.json` configuration.

### Rebranding Changes:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R5): Renamed the project from "SmartCharts" to "DerivitivesCharts" throughout the file, including the app name and description.

### Configuration Changes:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R30): Set the `private` field to `false`, indicating that the package is now intended for public distribution.