### PR TITLE
chore: Jim/use pat instead of gh token

### DIFF
--- a/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
+++ b/.github/workflows/publish_deriv_charts_and_update_deriv_app.yml
@@ -101,7 +101,7 @@ jobs:
             - name: Create Pull Request to derivatives-trader
               uses: peter-evans/create-pull-request@76c6f5c20e2111bfee3cd30fae52a25e410f5efc
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
                   commit-message: 'chore: update @deriv-com/derivatives-charts to ${{ steps.check_new_version.outputs.new_version }}'
                   title: 'Update derivatives-charts to ${{ steps.check_new_version.outputs.new_version }}'
                   body: 'This PR updates @deriv-com/derivatives-charts to ${{ steps.check_new_version.outputs.new_version }}'


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by changing the authentication token used for creating pull requests in the `publish_deriv_charts_and_update_deriv_app.yml` workflow.

- Updated the `create-pull-request` GitHub Action to use `${{ secrets.PERSONAL_ACCESS_TOKEN }}` instead of the default `${{ secrets.GITHUB_TOKEN }}` for authentication when creating pull requests in the workflow file `.github/workflows/publish_deriv_charts_and_update_deriv_app.yml`.