### PR TITLE
chore: update @deriv-com/shiftai-cli to version ^1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "@commitlint/cli": "^19.3.0",
                 "@commitlint/config-conventional": "^19.2.2",
                 "@commitlint/cz-commitlint": "^19.2.0",
-                "@deriv-com/shiftai-cli": "^0.0.6",
+                "@deriv-com/shiftai-cli": "^1.0.2",
                 "@deriv/api-types": "^1.0.47",
                 "@semantic-release/changelog": "^6.0.3",
                 "@semantic-release/github": "^9.2.6",
@@ -4180,9 +4180,9 @@
             }
         },
         "node_modules/@deriv-com/shiftai-cli": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/@deriv-com/shiftai-cli/-/shiftai-cli-0.0.6.tgz",
-            "integrity": "sha512-T5J4fNn3hM/nNAQyzL4yN2jWr0+xRlb7dsecPzX1lmPL/8vG4RfxPPSq7Ye+TMhi8W64NGalWZdlVx/bTJdiEg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@deriv-com/shiftai-cli/-/shiftai-cli-1.0.2.tgz",
+            "integrity": "sha512-lwzIfwej79c+580AFI5ej1VIEmsW8LHmeFtWBSWZv0j95YuqM9kFKzwL8r7JKodX4EMxssF8PW2hAT0z07mjTA==",
             "dev": true,
             "dependencies": {
                 "boxen": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@commitlint/cz-commitlint": "^19.2.0",
-        "@deriv-com/shiftai-cli": "^0.0.6",
+        "@deriv-com/shiftai-cli": "^1.0.2",
         "@deriv/api-types": "^1.0.47",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/github": "^9.2.6",


### PR DESCRIPTION
This pull request updates the version of the `@deriv-com/shiftai-cli` dependency in the `package.json` file to ensure compatibility with the latest features and bug fixes.

- Dependency update:
  * Upgraded `@deriv-com/shiftai-cli` from version `0.0.6` to `1.0.2` in `package.json` to use the latest improvements and fixes.