### PR TITLE
revert: revert code changes related to painter.ts callback parameter …

### DIFF
--- a/src/flutter-chart/painter.ts
+++ b/src/flutter-chart/painter.ts
@@ -1,31 +1,18 @@
-// This is a temporary fix. We'll need to remove the reset from the _playNewTickAnimation method
-// in the ../flutter-chart/lib/src/deriv_chart/chart/basic_chart.dart file which is the correct way to fix this.
-
 type TPainterCallback = (currentTickPercent: number) => void;
 
-type TPainterCallbackEntry = {
-    callback: TPainterCallback;
-    useSmoothAnimation: boolean;
-};
 export default class Painter {
-    callbacks: TPainterCallbackEntry[] = [];
+    callbacks: TPainterCallback[] = [];
 
     onPaint = (currentTickPercent: number) => {
-        this.callbacks.forEach(entry => {
-            if (entry.useSmoothAnimation) {
-                entry.callback(0);
-            } else {
-                entry.callback(currentTickPercent);
-            }
-        });
+        this.callbacks.forEach(cb => cb(currentTickPercent));
     };
 
-    registerCallback = (callback: TPainterCallback, useSmoothAnimation = false) => {
-        this.callbacks.push({ callback, useSmoothAnimation });
+    registerCallback = (callback: TPainterCallback) => {
+        this.callbacks.push(callback);
     };
 
     unregisterCallback = (callback: TPainterCallback) => {
-        const index = this.callbacks.findIndex(item => item.callback === callback);
+        const index = this.callbacks.findIndex(item => item === callback);
         this.callbacks.splice(index, 1);
     };
 }

--- a/src/store/PriceLineStore.ts
+++ b/src/store/PriceLineStore.ts
@@ -84,7 +84,7 @@ export default class PriceLineStore {
             }
         );
 
-        this.mainStore.chartAdapter.painter.registerCallback(this.drawBarrier, true);
+        this.mainStore.chartAdapter.painter.registerCallback(this.drawBarrier);
     };
 
     drawBarrier(currentTickPercent: number) {


### PR DESCRIPTION
This pull request simplifies the callback management in the `Painter` class by removing the `useSmoothAnimation` option and related logic. This change streamlines how callbacks are registered and invoked, resulting in cleaner and more maintainable code. Additionally, the registration of the `drawBarrier` callback in the `PriceLineStore` is updated to match the new interface.

**Refactoring and simplification of callback logic:**

* [`src/flutter-chart/painter.ts`](diffhunk://#diff-b1c7a7fcddcfff84b1d53153b11e801fff629b68951cfebdbf5686d628eef066L1-R15): Removed the `TPainterCallbackEntry` type and the `useSmoothAnimation` parameter from the callback registration process. The `Painter` class now manages a simple list of callbacks and always calls them with the current tick percent.

**Update to callback registration:**

* [`src/store/PriceLineStore.ts`](diffhunk://#diff-de59e04f532994bff5568d62c08abe35a05184be6801563c1b6bbc7d2123b186L87-R87): Updated the registration of the `drawBarrier` callback to remove the now-obsolete `useSmoothAnimation` argument.